### PR TITLE
Corrected KITTI path in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The training script can be run by calling `train.py` with the name of the experi
 ```
 python train.py name-of-experiment --gpu 0
 ```
-By default data will be read from `data/kitti/objects` and model checkpoints will be saved to `experiments`. The model is trained using the KITTI 3D object detection benchmark which can be downloaded from [here](http://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d). See `train.py` for a full list of training options.
+By default data will be read from `data/kitti/object` and model checkpoints will be saved to `experiments`. The model is trained using the KITTI 3D object detection benchmark which can be downloaded from [here](http://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d). See `train.py` for a full list of training options.
 
 ## Inference
 To decode the network predictions and visualise the resulting bounding boxes, run the `infer.py` script with the path to the model checkpoint you wish to visualise:


### PR DESCRIPTION
The Kitti path in readme.md was 'data/kitti/objects' where in the dataloader code is 'data/kitti/object' 

The letter 's' was removed from 'objects'