### PR TITLE
Fix command line argument to match README instructions

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -9,7 +9,7 @@ from oft import KittiObjectDataset, OftNet, ObjectEncoder, visualize_objects
 def parse_args():
     parser = ArgumentParser()
 
-    parser.add_argument('model-path', type=str,
+    parser.add_argument('model_path', type=str,
                         help='path to checkpoint file containing trained model')
     parser.add_argument('-g', '--gpu', type=int, default=0,
                         help='gpu to use for inference (-1 for cpu)')


### PR DESCRIPTION
Updated the model-path argument to model_path in parse_args to fix the error that occurs when following the command line example given in the README (python infer.py /path/to/checkpoint.pth.gz --gpu 0). This change ensures the code executes as documented.